### PR TITLE
Add `uninstall` and `zap` stanzas

### DIFF
--- a/Casks/notepadnext.rb
+++ b/Casks/notepadnext.rb
@@ -17,5 +17,11 @@ cask 'notepadnext' do
   app "Notepadnext.app"
   binary "#{appdir}/Notepadnext.app/Contents/MacOS/NotepadNext", target: "notepad-next"
 
-  # No zap stanza required
+  uninstall quit: "io.github.dail8859.NotepadNext"
+
+  zap trash: [
+    "~/.config/NotepadNext",
+    "~/Library/Application Support/NotepadNext",
+    "~/Library/Saved Application State/io.github.dail8859.NotepadNext.savedState",
+  ]
 end


### PR DESCRIPTION
Reference: https://docs.brew.sh/Cask-Cookbook

## Stanza: `uninstall`

> `quit:` (string or array) - bundle IDs of running applications to quit

## Stanza: `zap`

> The `zap` stanza describes a more complete uninstallation of files associated with a cask.