### PR TITLE
Publish v0.13 release and update with SHA256 of cask

### DIFF
--- a/Casks/notepadnext.rb
+++ b/Casks/notepadnext.rb
@@ -1,6 +1,6 @@
 cask 'notepadnext' do
-  version '0.12'
-  sha256 'fee630030112da083be81628750c1da3d0b9ac85f070dc2c14b119af19c3822c'
+  version '0.13'
+  sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
   url "https://github.com/dail8859/NotepadNext/releases/download/v#{version}//NotepadNext-v#{version}.dmg"
   name 'NotepadNext'

--- a/Casks/notepadnext.rb
+++ b/Casks/notepadnext.rb
@@ -2,7 +2,7 @@ cask 'notepadnext' do
   version '0.13'
   sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
-  url "https://github.com/dail8859/NotepadNext/releases/download/v#{version}//NotepadNext-v#{version}.dmg"
+  url "https://github.com/dail8859/NotepadNext/releases/download/v#{version}/NotepadNext-v#{version}.dmg"
   name 'NotepadNext'
   desc 'A cross-platform, reimplementation of Notepad++.'
   homepage 'https://github.com/dail8859/NotepadNext'


### PR DESCRIPTION
This PR bumps the version number to v0.13, updates the SHA256, and then remove the extra slash in the URL. Closes #926 in dail8859/NotepadNext.