### PR TITLE
Fix deprecated `depends_on macos:` string comparison format

### DIFF
--- a/Casks/notepadnext.rb
+++ b/Casks/notepadnext.rb
@@ -12,7 +12,7 @@ cask 'notepadnext' do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "Notepadnext.app"
   binary "#{appdir}/Notepadnext.app/Contents/MacOS/NotepadNext", target: "notepad-next"


### PR DESCRIPTION
## Fix deprecated `depends_on macos:` string comparison format

### Change
Line 15: `depends_on macos: ">= :big_sur"` → `depends_on macos: :big_sur`

### Reason
Homebrew now warns:
> "Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :big_sur` instead."

Per the [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook#depends_on-macos), the symbol form `depends_on macos: :big_sur` is the preferred syntax for readability and the string comparison format `">= :big_sur"` is deprecated.